### PR TITLE
Add a page for Lean, "The Lean Proof Assistant and Programming Language Resource Guide"

### DIFF
--- a/lean.md
+++ b/lean.md
@@ -1,0 +1,78 @@
+---
+layout: default
+title: The Lean Proof Assistant and Programming Language Resource Guide
+---
+
+{{ page.title }}
+================
+
+## Popular science articles
+
+* [A.I. Is Coming for Mathematics, Too](https://www.nytimes.com/2023/07/02/science/ai-mathematics-machine-learning.html), New York Times article. ([archive link](https://archive.ph/32fpQ))
+* [How will AI change mathematics?](https://www.nature.com/articles/d41586-023-00487-2), Nature news article. ([archive link](https://archive.ph/GmP3h)) 
+* [The Effort to Build the Mathematical Library of the Future](https://www.wired.com/story/the-effort-to-build-the-mathematical-library-of-the-future/), Wired article about the Lean mathematical library.
+* [Why Mathematical Proof Is a Social Compact](https://www.quantamagazine.org/why-mathematical-proof-is-a-social-compact-20230831/), Quanta article mentioning Lean, [video](https://www.youtube.com/watch?v=3l1RMiGeTfU).
+* [Mathematicians welcome computer-assisted proof in ‘grand unification’ theory](https://www.nature.com/articles/d41586-021-01627-2), Nature news article about the Liquid Tensor experiment where Lean was used to verify Peter Scholze’s latest result, Fields Medal 2018. ([archive link](https://archive.ph/OeilP))
+* [Proof Assistant Makes Jump to Big-League Math](https://www.quantamagazine.org/lean-computer-program-confirms-peter-scholze-proof-20210728/), Quanta article about the Liquid Tensor experiment.
+* Lean has been mentioned in Quanta’s The Year in Math and Computer Science two years in a row: [2020](https://www.quantamagazine.org/the-year-in-math-and-computer-science-20201223/) and [2021](https://www.quantamagazine.org/the-year-in-math-and-computer-science-20211223/).
+* [Will AI replace mathematicians?](https://bigthink.com/the-future/artificial-intelligence-replace-mathematicians/), Jordan Ellenberg’s article at Big Think.
+* [The Deep Link Equating Math Proofs and Computer Programs](https://www.quantamagazine.org/the-deep-link-equating-math-proofs-and-computer-programs-20231011/), Quanta article that mentions Lean.
+* [‘A-Team’ of Math Proves a Critical Link Between Addition and Sets.](https://www.quantamagazine.org/a-team-of-math-proves-a-critical-link-between-addition-and-sets-20231206/) Quanta article that mentions Lean.
+
+##  External AI efforts based on Lean
+
+* OpenAI: [Solving (some) formal math olympiad problems](https://openai.com/research/formal-math). ([paper](https://arxiv.org/abs/2202.01344))
+* Meta AI: [Teaching AI advanced mathematical reasoning](https://ai.meta.com/blog/ai-math-theorem-proving/). ([paper](https://arxiv.org/abs/2205.11491))
+* [LeanDojo](https://leandojo.org/): open source models, datasets, and code for Lean. ([paper](https://arxiv.org/abs/2306.15626), [video](https://www.youtube.com/watch?v=u-pkmdkQoMU))
+* [xAI](https://x.ai/): adding support for Lean to Grok.
+* [Morph labs](https://morph.so/): developing [ML models for Lean](https://morph.so/blog/the-personal-ai-proof-engineer/) and [moogle.ai](http://moogle.ai/), an AI for searching the Lean mathematical library using natural language.
+* DeepMind: They have formalized a result related to AI safety in Lean. ([paper](https://arxiv.org/abs/2311.14125), [code](https://github.com/google-deepmind/debate))
+
+## Tools for controlling and extracting data from Lean
+
+* Read-eval-print-loop via Json messages: <https://github.com/leanprover-community/repl>
+* Extracting data: <https://github.com/semorrison/lean-training-data>
+
+## Social media
+
+* Twitter: <https://twitter.com/leanprover>
+* LinkedIn: <https://www.linkedin.com/company/lean-fro>
+* Mastodon: <https://functional.cafe/@leanprover>
+* Tim Gowers [on Lean](https://twitter.com/wtgowers/status/1536275189339660288?lang=en), Fields Medalist [1998](https://en.wikipedia.org/wiki/Timothy_Gowers).
+* Terence Tao [posting that he decided to learn Lean](https://mathstodon.xyz/@tao/111206761117553482), Fields Medal [2006](https://en.wikipedia.org/wiki/Terence_Tao). He used Lean to find a [bug in one his papers](https://mathstodon.xyz/@tao/111287749336059662). Tao’s [blog post](https://terrytao.wordpress.com/2023/11/18/formalizing-the-proof-of-pfr-in-lean4-using-blueprint-a-short-tour/) on the PFR project using Lean.
+* [Interview with Peter Scholze](https://xenaproject.wordpress.com/2021/06/05/half-a-year-of-the-liquid-tensor-experiment-amazing-developments/), Fields Medal [2018](https://en.wikipedia.org/wiki/Peter_Scholze).
+
+## Books and manuals
+
+* [Functional Programming in Lean](https://lean-lang.org/functional_programming_in_lean/)
+* [The Mechanics of Proof](https://hrmacbeth.github.io/math2001/)
+* [Mathematics in Lean](https://leanprover-community.github.io/mathematics_in_lean/index.html)
+* [Theorem Proving in Lean 4](https://lean-lang.org/theorem_proving_in_lean4/)
+* [Metaprogramming in Lean 4](https://github.com/leanprover-community/lean4-metaprogramming-book)
+* [Reference Manual](https://lean-lang.org/lean4/doc/) (work in progress)
+* [How to Prove it with Lean](https://djvelleman.github.io/HTPIwL/), based on the textbook [*How To Prove It: A Structured Approach, 3rd edition*](https://www.amazon.com/How-Prove-Structured-Daniel-Velleman/dp/1108439535/)
+
+## Websites
+
+* Homepage: <https://lean-lang.org>
+* Web editor (try Lean in your web browser): <https://live.lean-lang.org>
+* Lean nonprofit: <https://lean-fro.org>
+* Lean community website: <https://leanprover-community.github.io>
+* Main libraries documentation: <https://leanprover-community.github.io/mathlib4_docs>
+* Loogle (search libraries online): <https://loogle.lean-lang.org>
+* Reservoir (package repository, work in progress): <https://reservoir.lean-lang.org>
+* Discussion channel: <https://leanprover.zulipchat.com>
+* Upcoming and past Lean-related events and conferences: <https://leanprover-community.github.io/events.html>
+
+## Videos and podcasts
+
+* [Machine-Checked Proofs and the Rise of Formal Methods in Mathematics](https://www.youtube.com/watch?v=ekYeqvMcaWQ&list=PLgKuh-lKre11Hkeo5UnqhYZzY35Y70z5y) at Simons Institute, October 2023
+* [The Rise of Formalism in Mathematics](https://www.youtube.com/watch?v=SEID4XYFN7o), by Kevin Buzzard at ICML 2022.
+* [Hoskinson Center for Formal Mathematics](https://www.youtube.com/watch?v=3snIzhjqsk0&t=501s) at CMU, Charles Hoskinson, 2021.
+* [Jeremy Avigad at the opening of the Hoskinson Center](https://www.youtube.com/watch?v=tbz6cdnFyPc) at CMU, 2021.
+* [Automated Mathematical Proofs](https://www.youtube.com/watch?v=prYaTrZUces) - Computerphile.
+* [Z3 and Lean, the Spiritual Journey](https://www.typetheoryforall.com/2023/09/09/33-Leo-de-Moura.html), Type Theory Forall podcast. 
+* [The Future of Mathematics?](https://www.youtube.com/watch?v=Dp-mQ3HxgDE), by Kevin Buzzard at MSR
+* [Combining the Worlds of Automated and Interactive Theorem Proving in Lean](https://building-better-systems.simplecast.com/episodes/14-leo-de-moura-combining-the-worlds-of-automated-and-interactive-theorem-proving-in-lean), Building Better Systems podcast.
+* [The Lean nonprofit YouTube channel](https://www.youtube.com/@LeanFRO-ch3kd).
+* [The Lean community YouTube channel](https://www.youtube.com/@leanprovercommunity5485/videos).


### PR DESCRIPTION
Once this PR is merged, https://leodemoura.github.io/lean.html will render like the following screenshot.

![Screenshot 2024-03-23 at 2 00 59 PM](https://github.com/leodemoura/leodemoura.github.com/assets/403281/91c40adc-c813-4c09-b4c8-725a051c01e5)
